### PR TITLE
fix: use OIDC trusted publishing instead of NPM_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,6 @@ jobs:
           createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
       
       - name: Send release notification


### PR DESCRIPTION
## Summary

- Remove `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` from release workflow — the token was expired/revoked
- Rely on GitHub OIDC trusted publisher configured on npmjs.com for authentication (`id-token: write` + `--provenance`)

## Context

The v0.2.0 release PR (#5) was merged but npm publish failed with `E404` because `NPM_TOKEN` was expired. npmjs.com already has OIDC trusted publishing configured for this repo's `release.yml` workflow — no token needed.

## Test plan

- [ ] CI passes (no test changes)
- [ ] After merge, re-run release workflow to publish v0.2.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)