### PR TITLE
fix: remove registry-url to allow OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,6 @@ jobs:
         with:
           node-version: 20
           cache: 'pnpm'
-          registry-url: 'https://registry.npmjs.org'
       
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -46,7 +45,6 @@ jobs:
           createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_CONFIG_PROVENANCE: true
       
       - name: Send release notification
         if: steps.changesets.outputs.published == 'true'


### PR DESCRIPTION
## Summary

- Remove `registry-url` from `setup-node` — it creates `.npmrc` with `_authToken=${NODE_AUTH_TOKEN}` which overrides OIDC authentication
- Remove redundant `NPM_CONFIG_PROVENANCE` env var (already passed via `--provenance` flag)

## Context

PR #8 removed the explicit `NODE_AUTH_TOKEN` env var, but `setup-node` with `registry-url` still creates an `.npmrc` referencing `${NODE_AUTH_TOKEN}`. npm reads this and attempts token-based auth instead of falling through to OIDC trusted publishing.

npm's default registry is already `https://registry.npmjs.org`, so `registry-url` is unnecessary.

## Test plan

- [ ] CI passes
- [ ] After merge, release workflow publishes v0.2.0 via OIDC

🤖 Generated with [Claude Code](https://claude.com/claude-code)