### PR TITLE
fix: pre-create .npmrc for OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,17 +34,21 @@ jobs:
       
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-      
+
+      - name: Configure npm for OIDC trusted publishing
+        run: echo "registry=https://registry.npmjs.org/" > .npmrc
+
       - name: Create Release Pull Request or Publish
         id: changesets
         uses: changesets/action@v1
         with:
-          publish: pnpm changeset publish --provenance
+          publish: pnpm changeset publish
           title: 'chore: release'
           commit: 'chore: release'
           createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true
       
       - name: Send release notification
         if: steps.changesets.outputs.published == 'true'


### PR DESCRIPTION
## Summary

- Pre-create `.npmrc` with just `registry=https://registry.npmjs.org/` before changesets runs
- This prevents `changesets/action` from creating its own `.npmrc` with `_authToken=${NODE_AUTH_TOKEN}` placeholder
- Set `NPM_CONFIG_PROVENANCE=true` env var (more reliable than `--provenance` CLI flag through changesets)

## Root cause

`changesets/action@v1` [creates `.npmrc`](https://github.com/changesets/action/blob/main/src/index.ts) with `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` when no `.npmrc` exists. With `NODE_AUTH_TOKEN` unset, npm gets `ENEEDAUTH` before attempting OIDC.

## Test plan

- [ ] CI passes
- [ ] After merge, release workflow publishes v0.2.0 via OIDC trusted publishing

🤖 Generated with [Claude Code](https://claude.com/claude-code)