### PR TITLE
fix: write .npmrc to $HOME for changesets OIDC auth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Configure npm for OIDC trusted publishing
-        run: echo "registry=https://registry.npmjs.org/" > .npmrc
+        run: echo "registry=https://registry.npmjs.org/" > "$HOME/.npmrc"
 
       - name: Create Release Pull Request or Publish
         id: changesets


### PR DESCRIPTION
## Summary

Write `.npmrc` to `$HOME/.npmrc` instead of `./.npmrc` — `changesets/action` checks `$HOME/.npmrc` (not workspace root) to decide whether to create its own `.npmrc` with `_authToken=${NODE_AUTH_TOKEN}`.

## Test plan

- [ ] CI passes
- [ ] Release workflow log shows "Found existing .npmrc file" instead of "No user .npmrc file found"
- [ ] v0.2.0 published via OIDC

🤖 Generated with [Claude Code](https://claude.com/claude-code)