### PR TITLE
fix: override changesets .npmrc in publish command for OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,9 +29,10 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: 'pnpm'
-      
+          registry-url: 'https://registry.npmjs.org'
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -39,26 +40,16 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          publish: bash -c 'echo "registry=https://registry.npmjs.org/" > "$HOME/.npmrc" && npm publish --provenance --access public'
+          publish: pnpm changeset publish
           title: 'chore: release'
           commit: 'chore: release'
           createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      
+          NPM_CONFIG_PROVENANCE: true
+
       - name: Send release notification
         if: steps.changesets.outputs.published == 'true'
         run: |
-          echo "🎉 New version published!"
+          echo "New version published!"
           echo "Published packages: ${{ steps.changesets.outputs.publishedPackages }}"
-      
-      # Optional: Send Slack notification on release
-      # - name: Notify Slack on Release
-      #   if: steps.changesets.outputs.published == 'true'
-      #   uses: 8398a7/action-slack@v3
-      #   with:
-      #     status: success
-      #     text: '🚀 @tenderlift/simap-client has been released!'
-      #     webhook_url: ${{ secrets.SLACK_WEBHOOK }}
-      #   env:
-      #     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,20 +35,16 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Configure npm for OIDC trusted publishing
-        run: echo "registry=https://registry.npmjs.org/" > "$HOME/.npmrc"
-
       - name: Create Release Pull Request or Publish
         id: changesets
         uses: changesets/action@v1
         with:
-          publish: pnpm changeset publish
+          publish: bash -c 'echo "registry=https://registry.npmjs.org/" > "$HOME/.npmrc" && npm publish --provenance --access public'
           title: 'chore: release'
           commit: 'chore: release'
           createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_CONFIG_PROVENANCE: true
       
       - name: Send release notification
         if: steps.changesets.outputs.published == 'true'


### PR DESCRIPTION
## Summary

`changesets/action` always injects `_authToken=${NODE_AUTH_TOKEN}` into `$HOME/.npmrc` — even when it finds an existing one (it appends the auth line). This blocks npm's OIDC trusted publishing flow.

Fix: the publish command itself overwrites `$HOME/.npmrc` with just the registry URL, then calls `npm publish --provenance --access public` directly. With no auth token in `.npmrc` and `id-token: write` permission, npm performs the OIDC token exchange natively.

## What changed

```yaml
# Before (changesets injects auth token, blocks OIDC)
publish: pnpm changeset publish

# After (clear auth, let npm handle OIDC)
publish: bash -c 'echo "registry=https://registry.npmjs.org/" > "$HOME/.npmrc" && npm publish --provenance --access public'
```

## Test plan

- [ ] CI passes
- [ ] Release workflow publishes v0.2.0 via OIDC

🤖 Generated with [Claude Code](https://claude.com/claude-code)