### PR TITLE
fix: remove registry-url to let npm use OIDC natively

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,6 @@ jobs:
         with:
           node-version: 22
           cache: 'pnpm'
-          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary

- Remove `registry-url` from `setup-node` — it creates `.npmrc` with `_authToken=${NODE_AUTH_TOKEN}`, which makes npm use that (invalid) token instead of OIDC exchange
- This matches [hey-api/openapi-ts](https://github.com/hey-api/openapi-ts/blob/main/.github/workflows/release.yml)'s working changesets + OIDC setup

## Root cause

Run [#21938213183](https://github.com/TenderLift/simap-client/actions/runs/21938213183) showed OIDC provenance signing succeeded (Node 22 fix worked), but npm used the `NODE_AUTH_TOKEN` injected by `setup-node`'s `registry-url` instead of the OIDC token for the actual publish:

```
NODE_AUTH_TOKEN: XXXXX-XXXXX-XXXXX-XXXXX  ← injected by setup-node
Access token expired or revoked.           ← npm used it instead of OIDC
```

## Test plan

- [ ] Merge to main, release workflow triggers
- [ ] `pnpm changeset publish` uses OIDC (no "Access token expired" error)
- [ ] v0.2.0 appears on npmjs.com with provenance badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)