### PR TITLE
fix: pin changesets/action@v1.7.0 for native OIDC support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,6 @@ jobs:
         with:
           node-version: 22
           cache: 'pnpm'
-          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Create Release Pull Request or Publish
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@v1.7.0
         with:
           publish: pnpm changeset publish
           title: 'chore: release'


### PR DESCRIPTION
## Summary

- Pin `changesets/action` to `v1.7.0` which has native OIDC/trusted publishing support
- Versions before v1.6.0 always create `.npmrc` with `_authToken=${NODE_AUTH_TOKEN}`, blocking npm OIDC exchange
- v1.7.0 detects `ACTIONS_ID_TOKEN_REQUEST_TOKEN` and skips `.npmrc` creation, letting npm handle OIDC natively

## Root cause

`changesets/action@v1` resolved to the `v1` branch, which at run time (08:23 UTC) pointed to a pre-OIDC commit. The branch was updated to v1.7.0 at 11:26 UTC — after our run. Pinning to `@v1.7.0` ensures we always get OIDC support.

## Test plan

- [ ] Merge to main, release workflow triggers
- [ ] Logs show "OIDC is available - using npm trusted publishing" (not "creating .npmrc")
- [ ] v0.2.0 published to npmjs.com with provenance badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)