### PR TITLE
fix: upgrade npm for OIDC trusted publishing support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,9 @@ jobs:
           node-version: 22
           cache: 'pnpm'
 
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
## Summary

- Add `npm install -g npm@latest` step before publish
- Node 22.22.0 ships with **npm 10.9.4** which does NOT support OIDC trusted publishing (requires npm >= 11.5.1)

## Context

Previous run confirmed changesets/action@v1.7.0 correctly detects OIDC:
```
No NPM_TOKEN found, but OIDC is available - using npm trusted publishing
```
But npm 10.9.4 doesn't know how to exchange the OIDC token, resulting in `ENEEDAUTH`.

## Test plan

- [ ] Workflow logs show npm 11.x+ after upgrade step
- [ ] `pnpm changeset publish` succeeds with OIDC auth
- [ ] v0.2.0 published to npmjs.com with provenance badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)