### PR TITLE
fix: use Node 24 for native npm OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,27 +13,30 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-      id-token: write # For npm provenance
-    
+      id-token: write # For npm OIDC trusted publishing
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-      
+
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
           version: 10.14.0
-      
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: 'pnpm'
 
-      - name: Upgrade npm for OIDC trusted publishing
-        run: npm install -g npm@latest
+      - name: Debug versions
+        run: |
+          node --version
+          npm --version
+          which npm
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary

- Switch release workflow from Node 22 to Node 24
- Node 22 ships with npm 10.9.4 — does NOT support OIDC trusted publishing
- Node 24 ships with npm 11+ natively, with full OIDC support
- Remove the `npm install -g` upgrade step (no longer needed)
- Add debug version logging step

## Context

Previous attempt (PR #15) upgraded npm globally but `pnpm changeset publish` still got ENEEDAUTH. The globally upgraded npm may not fully replace the Node 22 integrated npm for OIDC token exchange. Node 24 avoids this entirely.

## Test plan

- [ ] Debug step shows npm 11.x+
- [ ] Publish succeeds with OIDC auth
- [ ] v0.2.0 on npmjs.com with provenance badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)