### PR TITLE
fix: use npm publish directly to test OIDC without changesets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,26 +32,22 @@ jobs:
           node-version: 24
           cache: 'pnpm'
 
-      - name: Debug versions
-        run: |
-          node --version
-          npm --version
-          which npm
-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
 
       - name: Create Release Pull Request or Publish
         id: changesets
         uses: changesets/action@v1.7.0
         with:
-          publish: pnpm changeset publish
+          publish: npm publish --provenance --access public
           title: 'chore: release'
           commit: 'chore: release'
           createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_CONFIG_PROVENANCE: true
 
       - name: Send release notification
         if: steps.changesets.outputs.published == 'true'


### PR DESCRIPTION
## Summary

- Replace `pnpm changeset publish` with `npm publish --provenance --access public`
- Add explicit `pnpm build` step before publish
- This tests whether npm OIDC works when called directly vs through changesets/pnpm

## Context

All previous attempts failed with ENEEDAUTH despite npm 11.6.2 on Node 24. The `--git-checks` warning in logs suggests `pnpm changeset publish` adds pnpm-specific flags that may interfere with npm's OIDC flow. This PR isolates the variable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)