### PR TITLE
fix: restore registry-url and clear NODE_AUTH_TOKEN for OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           node-version: 24
           cache: 'pnpm'
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -48,6 +49,7 @@ jobs:
           createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ''
 
       - name: Send release notification
         if: steps.changesets.outputs.published == 'true'


### PR DESCRIPTION
## Summary

- Restore `registry-url` so setup-node creates `.npmrc` with registry config
- Explicitly set `NODE_AUTH_TOKEN: ''` to clear any default token and force OIDC fallback
- Per [github.com/orgs/community/discussions/176761](https://github.com/orgs/community/discussions/176761), setup-node may set a default token that blocks OIDC

## Test plan

- [ ] npm does OIDC token exchange (no ENEEDAUTH)
- [ ] v0.2.0 published with provenance

🤖 Generated with [Claude Code](https://claude.com/claude-code)