### PR TITLE
fix: remove registry-url to allow npm OIDC fallback

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,6 @@ jobs:
         with:
           node-version: 24
           cache: 'pnpm'
-          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -49,7 +48,6 @@ jobs:
           createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ''
 
       - name: Send release notification
         if: steps.changesets.outputs.published == 'true'


### PR DESCRIPTION
## Summary

- Remove `registry-url` from `setup-node` — it creates `.npmrc` with `_authToken=${NODE_AUTH_TOKEN}` which npm treats as "auth configured but empty" even when the value is blank, preventing OIDC fallback
- Remove `NODE_AUTH_TOKEN: ''` override (no longer needed)

## Root cause

`setup-node` with `registry-url` creates `/home/runner/work/_temp/.npmrc` containing:
```
//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
```
And exports `NODE_AUTH_TOKEN` set to `GITHUB_TOKEN`. Even when we override `NODE_AUTH_TOKEN: ''` in the publish step, npm reads `_authToken=` (empty string) and considers auth **configured** — it never falls through to OIDC token exchange.

Without `registry-url`, setup-node creates no `.npmrc` and exports no `NODE_AUTH_TOKEN`. npm 11.6.2 (Node 24) defaults to `registry.npmjs.org` and with no auth configured, uses OIDC for authentication.

This is different from PR #13 (which also removed registry-url) because we now use `changesets/action@v1.7.0` which detects OIDC and skips its own `.npmrc` creation.

## Test plan

- [ ] Release workflow runs successfully after merge
- [ ] npm publish uses OIDC authentication (no ENEEDAUTH)
- [ ] v0.2.0 appears on npmjs.com with provenance badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)