### PR TITLE
fix: add OIDC debug and NPM_CONFIG_PROVENANCE for trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,23 @@ jobs:
       - name: Build
         run: pnpm build
 
+      - name: Debug OIDC environment
+        run: |
+          echo "Node: $(node -v)"
+          echo "npm: $(npm -v)"
+          echo "OIDC token URL set: ${ACTIONS_ID_TOKEN_REQUEST_URL:+yes}"
+          echo "OIDC token set: ${ACTIONS_ID_TOKEN_REQUEST_TOKEN:+yes}"
+          echo "NPM_CONFIG_USERCONFIG: ${NPM_CONFIG_USERCONFIG:-not set}"
+          echo "NODE_AUTH_TOKEN set: ${NODE_AUTH_TOKEN:+yes}"
+          echo "--- npm config ---"
+          npm config list
+          echo "--- .npmrc files ---"
+          cat "$HOME/.npmrc" 2>/dev/null || echo "No ~/.npmrc"
+          cat .npmrc 2>/dev/null || echo "No ./.npmrc"
+          if [ -n "$NPM_CONFIG_USERCONFIG" ]; then
+            cat "$NPM_CONFIG_USERCONFIG" 2>/dev/null || echo "No userconfig file"
+          fi
+
       - name: Create Release Pull Request or Publish
         id: changesets
         uses: changesets/action@v1.7.0
@@ -48,6 +65,7 @@ jobs:
           createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_CONFIG_PROVENANCE: 'true'
 
       - name: Send release notification
         if: steps.changesets.outputs.published == 'true'


### PR DESCRIPTION
## Summary

- Add debug step to verify OIDC env vars (`ACTIONS_ID_TOKEN_REQUEST_URL/TOKEN`), npm config, and `.npmrc` state before publish
- Add `NPM_CONFIG_PROVENANCE: true` env var per [npm/cli#8730](https://github.com/npm/cli/issues/8730) — may trigger OIDC token exchange

## Context

PR #19 removed `registry-url` but npm still fails with ENEEDAUTH. The debug step will reveal:
1. Whether OIDC env vars are available to the runner
2. What npm config looks like (any stale auth entries)
3. Whether any `.npmrc` files contain auth tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)