### PR TITLE
chore: clean up release workflow after successful OIDC publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,18 +38,6 @@ jobs:
       - name: Build
         run: pnpm build
 
-      - name: Debug OIDC environment
-        run: |
-          echo "Node: $(node -v)"
-          echo "npm: $(npm -v)"
-          echo "OIDC token URL set: ${ACTIONS_ID_TOKEN_REQUEST_URL:+yes}"
-          echo "OIDC token set: ${ACTIONS_ID_TOKEN_REQUEST_TOKEN:+yes}"
-          echo "--- npm config ls -l (auth related) ---"
-          npm config ls -l 2>&1 | grep -i -E "(registry|auth|token|oidc|provenance)" || true
-          echo "--- Attempting direct npm publish with verbose logging ---"
-          npm publish --provenance --access public --loglevel verbose 2>&1 || true
-          echo "--- Exit code: $? ---"
-
       - name: Create Release Pull Request or Publish
         id: changesets
         uses: changesets/action@v1.7.0


### PR DESCRIPTION
## Summary

- Remove debug step now that npm OIDC trusted publishing is confirmed working
- v0.2.0 published successfully with provenance via OIDC

## Root cause (for posterity)

The npm trusted publisher config had `tenderlift/simap-client` (lowercase owner), but GitHub's OIDC token contains `TenderLift` (canonical casing). npm compares these **case-sensitively**, causing 404 "package not found" on the OIDC token exchange endpoint.

Fix: recreated the trusted publisher config on npmjs.com with the exact casing `TenderLift`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)